### PR TITLE
uploads: Support non-AWS S3-compatible server.

### DIFF
--- a/docs/production/upload-backends.md
+++ b/docs/production/upload-backends.md
@@ -35,20 +35,23 @@ as world-readable, whereas the "uploaded files" one is not.
 
 1. Comment out the `LOCAL_UPLOADS_DIR` setting in
    `/etc/zulip/settings.py` (add a `#` at the start of the line).
+   And uncomment the `S3_ENDPOINT_URL` setting.
 
 1. If you are using a non-AWS block storage provider, or certain AWS
    regions, you may need to explicitly
-   [configure boto](http://boto.cloudhackers.com/en/latest/boto_config_tut.html).
+   [configure boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file).
    For AWS, you may need to use AWS's SIGv4 signature format (because AWS has stopped
-    supporting the older v3 format in those regions); for other
+   supporting the older SIGv2 format in those regions); for other
    providers, you may just need to set the hostname.  You can do this
-    by adding an `/etc/zulip/boto.cfg` containing the following:
+   by adding an `/etc/zulip/aws.cfg` containing the following:
     ```
-    [s3]
-    use-sigv4 = True
-    # Edit to provide your bucket's AWS region or hostname here.
-    host = s3.eu-central-1.amazonaws.com
+    [default]
+    signature_version = s3v4
+    # Edit to provide your bucket's AWS region
+    region = ap-south-1
     ```
+    You may also need to set the `S3_ENDPOINT_URL` setting to
+    your endpoint url (e.g. `https://s3.amazonaws.com/`).
 
 
 1. You will need to configure `nginx` to direct requests for uploaded

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1273,7 +1273,7 @@ def export_files_from_s3(realm: Realm, bucket_name: str, output_dir: Path,
                          processing_avatars: bool=False, processing_emoji: bool=False,
                          processing_realm_icon_and_logo: bool=False) -> None:
     session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
-    s3 = session.resource('s3')
+    s3 = session.resource('s3', endpoint_url=settings.S3_ENDPOINT_URL)
     bucket = s3.Bucket(bucket_name)
     records = []
 

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -657,7 +657,7 @@ def import_uploads(realm: Realm, import_dir: Path, processes: int, processing_av
         else:
             bucket_name = settings.S3_AUTH_UPLOADS_BUCKET
         session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
-        bucket = session.resource('s3').Bucket(bucket_name)
+        bucket = session.resource('s3', endpoint_url=settings.S3_ENDPOINT_URL).Bucket(bucket_name)
 
     count = 0
     for record in records:

--- a/zerver/migrations/0149_realm_emoji_drop_unique_constraint.py
+++ b/zerver/migrations/0149_realm_emoji_drop_unique_constraint.py
@@ -55,7 +55,7 @@ class S3Uploader(Uploader):
         super().__init__()
         session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
         self.bucket_name = settings.S3_AVATAR_BUCKET
-        self.bucket = session.resource('s3').Bucket(self.bucket_name)
+        self.bucket = session.resource('s3', endpoint_url=settings.S3_ENDPOINT_URL).Bucket(self.bucket_name)
 
     def copy_files(self, src_key: str, dst_key: str) -> None:
         source = dict(Bucket=self.bucket_name, Key=src_key)

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -110,14 +110,7 @@ GENERATE_STRIPE_FIXTURES = False
 # This is overridden in test_settings.py for the test suites
 BAN_CONSOLE_OUTPUT = False
 
-# Google Compute Engine has an /etc/boto.cfg that is "nicely
-# configured" to work with GCE's storage service.  However, their
-# configuration is super aggressive broken, in that it means importing
-# boto in a virtualenv that doesn't contain the GCE tools crashes.
-#
-# By using our own path for BOTO_CONFIG, we can cause boto to not
-# process /etc/boto.cfg.
-os.environ['BOTO_CONFIG'] = '/etc/zulip/boto.cfg'
+os.environ['AWS_CONFIG_FILE'] = '/etc/zulip/aws.cfg'
 
 # These are the settings that we will check that the user has filled in for
 # production deployments before starting the app.  It consists of a series

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -116,7 +116,8 @@ DEFAULT_AVATAR_URI = '/static/images/default-avatar.png'
 DEFAULT_LOGO_URI = '/static/images/logo/zulip-org-logo.svg'
 S3_AVATAR_BUCKET = ''
 S3_AUTH_UPLOADS_BUCKET = ''
-S3_REGION = ''
+S3_REGION = None
+S3_ENDPOINT_URL = None
 LOCAL_UPLOADS_DIR: Optional[str] = None
 MAX_FILE_UPLOAD_SIZE = 25
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -406,7 +406,8 @@ ENABLE_FILE_LINKS = False
 LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 #S3_AUTH_UPLOADS_BUCKET = ""
 #S3_AVATAR_BUCKET = ""
-#S3_REGION = ""
+#S3_REGION = None
+#S3_ENDPOINT_URL = None
 
 # Maximum allowed size of uploaded files, in megabytes.  DO NOT SET
 # ABOVE 80MB.  The file upload implementation doesn't support chunked


### PR DESCRIPTION
Boto3 does not allow setting the endpoint url from
the config file. Thus we create a django setting
variable (`S3_ENDPOINT_URL`) which is passed to
service clients and resources of `boto3.Session`.

We also set the `AWS_CONFIG_FILE` environmental
variable instead of the `BOTO_CONFIG` variable.
This is done because for looking up the configuration
values boto3 searches for the `~/.aws/config` file,
as mentioned in the docs.

Fixes #16246.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing plan:** <!-- How have you tested? -->


**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
